### PR TITLE
Bugs fixes for #26

### DIFF
--- a/P-NetClient/AddTestPageViewModel.cs
+++ b/P-NetClient/AddTestPageViewModel.cs
@@ -52,7 +52,7 @@ namespace PNetClient
         /// </summary>
         public void SaveHosts()
         {
-            File.WriteAllText(".hosts", JsonSerializer.Serialize(SavedHosts));
+            File.WriteAllText(".hosts", JsonSerializer.Serialize(SavedHosts.Where((elem) => elem != "Unselect")));
         }
 
         /// <summary>

--- a/P-NetClient/Logger.cs
+++ b/P-NetClient/Logger.cs
@@ -94,7 +94,8 @@ namespace PNetClient
 
         public void Dispose()
         {
-            FileStream.Close();
+            if(FileStream != null)
+                FileStream.Close();
             foreach (PingTest pt in Manager.History.Keys)
                 Manager.History[pt].CollectionChanged -= HistoryCollectionChanged;
         }

--- a/P-NetClient/ServicePageViewModel.cs
+++ b/P-NetClient/ServicePageViewModel.cs
@@ -51,7 +51,7 @@ namespace PNetClient
                             List<(DateTime Time, int Ping)> Pings = new List<(DateTime Time, int Ping)>();
                             string[] fileName = fi.Name.Split("___");
                             string host = fileName[1].Replace('_', '.');
-                            StreamReader sr = fi.OpenText();
+                            StreamReader sr = new StreamReader(fi.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
                             while (!sr.EndOfStream)
                             {
                                 string? line = sr.ReadLine();

--- a/P-NetClient/TestPage.axaml.cs
+++ b/P-NetClient/TestPage.axaml.cs
@@ -22,6 +22,7 @@ namespace PNetClient
 
         public ObservableCollection<DataPoint> Values { get; set; }
 
+        bool TestInitializationCompleted { get; set; }
 
         public static readonly StyledProperty<string> TestNameProperty =
             AvaloniaProperty.Register<MenuRow, string>(nameof(TestName));
@@ -62,6 +63,7 @@ namespace PNetClient
                 {
                     Manager.History[pt].CollectionChanged += TestPage_CollectionChanged;
                     ListBox.Items = Manager.PingTests;
+                    TestInitializationCompleted = true;
                 });
             });
         }
@@ -89,7 +91,8 @@ namespace PNetClient
         private void btnStopTest(object sender, RoutedEventArgs e)
         {
             PingTest pt = Manager.PingTests.Find((pt) => pt.IpAddress.MapToIPv4().Equals(Manager.DestinationHost.MapToIPv4()));
-            Manager.History[pt].CollectionChanged -= TestPage_CollectionChanged;
+            if(TestInitializationCompleted)
+                Manager.History[pt].CollectionChanged -= TestPage_CollectionChanged;
             Logger.Dispose();
             Manager.Dispose();
             MainWindow.TestPages.Remove(this);

--- a/PNetService/Logger.cs
+++ b/PNetService/Logger.cs
@@ -50,7 +50,7 @@ namespace PNetService
                 string path = Path.Combine(Config.Instance.OutputPath, 
                     Manager.DestinationHost.ToString(), 
                     DateTime.Today.ToString("yyyy_MM_dd") + "___" + pt.IpAddress.ToString().Replace('.', '_'));
-                FileStreams.Add(pt, new FileStream(path, FileMode.Append, FileAccess.Write));
+                FileStreams.Add(pt, new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite));
                 LogTest(pt);
             }
         }

--- a/PNetService/PNetService.csproj
+++ b/PNetService/PNetService.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Closes #26

- Fixed: Saved hosts saves "Unselect"
- Fixed: Can't open files generated by service when it is running
- Fixed: Application crashed when test was closed before full initialization.